### PR TITLE
Handle auth outside request scope

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -41,6 +41,16 @@ export const authOptions: NextAuthOptions = {
 
 const handler = NextAuth(authOptions);
 
-export const auth = () => getServerSession(authOptions);
+export const auth = async () => {
+  try {
+    return await getServerSession(authOptions);
+  } catch (error) {
+    if (error instanceof Error && error.message.includes("outside a request scope")) {
+      return null;
+    }
+
+    throw error;
+  }
+};
 
 export { handler as GET, handler as POST };

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -41,11 +41,33 @@ export const authOptions: NextAuthOptions = {
 
 const handler = NextAuth(authOptions);
 
+const OUTSIDE_REQUEST_SCOPE_ERROR_CODE = "E251";
+
+function isOutsideRequestScopeError(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+
+  const { __NEXT_ERROR_CODE } = error as { __NEXT_ERROR_CODE?: unknown };
+
+  if (typeof __NEXT_ERROR_CODE === "string") {
+    return __NEXT_ERROR_CODE === OUTSIDE_REQUEST_SCOPE_ERROR_CODE;
+  }
+
+  if (error instanceof Error && error.message.includes("outside a request scope")) {
+    // Fallback for older Next.js builds that only expose the invariant message.
+    // The message originates from https://nextjs.org/docs/messages/next-dynamic-api-wrong-context.
+    return true;
+  }
+
+  return false;
+}
+
 export const auth = async () => {
   try {
     return await getServerSession(authOptions);
   } catch (error) {
-    if (error instanceof Error && error.message.includes("outside a request scope")) {
+    if (isOutsideRequestScopeError(error)) {
       return null;
     }
 

--- a/src/lib/deck-store/index.ts
+++ b/src/lib/deck-store/index.ts
@@ -13,7 +13,8 @@ export type {
   DeckStore,
 } from "./types";
 
-const useMemoryStore = process.env.ALIAS_TEST_DB === "memory";
+const isProductionBuildPhase = process.env.NEXT_PHASE === "phase-production-build";
+const useMemoryStore = process.env.ALIAS_TEST_DB === "memory" || isProductionBuildPhase;
 
 const store: DeckStore = useMemoryStore ? memoryDeckStore : dbDeckStore;
 

--- a/src/lib/deck-store/index.ts
+++ b/src/lib/deck-store/index.ts
@@ -13,8 +13,19 @@ export type {
   DeckStore,
 } from "./types";
 
-const isProductionBuildPhase = process.env.NEXT_PHASE === "phase-production-build";
-const useMemoryStore = process.env.ALIAS_TEST_DB === "memory" || isProductionBuildPhase;
+const ALIAS_TEST_DB_ENV_KEY = "ALIAS_TEST_DB" as const;
+const NEXT_PHASE_ENV_KEY = "NEXT_PHASE" as const;
+const MEMORY_STORE_VALUE = "memory" as const;
+const PRODUCTION_BUILD_PHASE = "phase-production-build" as const;
+
+const env = typeof process !== "undefined" ? process.env : undefined;
+
+const isProductionBuildPhase = (env?.[NEXT_PHASE_ENV_KEY] ?? null) === PRODUCTION_BUILD_PHASE;
+
+// Use a runtime lookup with bracket notation so Next.js doesn't inline the build-time
+// "phase-production-build" value into the compiled bundle (which would otherwise force the
+// memory store at runtime as well).
+const useMemoryStore = (env?.[ALIAS_TEST_DB_ENV_KEY] ?? null) === MEMORY_STORE_VALUE || isProductionBuildPhase;
 
 const store: DeckStore = useMemoryStore ? memoryDeckStore : dbDeckStore;
 


### PR DESCRIPTION
## Summary
- prevent the `auth` helper from throwing when called without a request context by returning `null`
- fall back to the in-memory deck store during production builds so a database connection isn't required

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d31df5465c832c9cad9f9d1d2d2ed4