### PR TITLE
Fix root layout structure and add global 404 page

### DIFF
--- a/src/app/404.tsx
+++ b/src/app/404.tsx
@@ -1,0 +1,30 @@
+import Link from "next/link";
+import { getTranslations } from "next-intl/server";
+
+import { defaultLocale } from "@/i18n/config";
+import { Button } from "@/components/ui/button";
+
+export default async function GlobalNotFoundPage() {
+  const t = await getTranslations({ locale: defaultLocale, namespace: "notFound" });
+
+  return (
+    <div className="flex min-h-screen flex-col">
+      <main className="flex-1">
+        <div className="bg-surface-muted/40 py-24">
+          <div className="mx-auto flex max-w-3xl flex-col items-center gap-6 px-6 text-center">
+            <h1 className="text-4xl font-semibold text-foreground">{t("title")}</h1>
+            <p className="max-w-xl text-sm text-foreground/70">{t("description")}</p>
+            <div className="flex flex-wrap items-center justify-center gap-3">
+              <Button asChild>
+                <Link href={`/${defaultLocale}`}>{t("ctaHome")}</Link>
+              </Button>
+              <Button asChild variant="ghost">
+                <Link href={`/${defaultLocale}/decks`}>{t("ctaDecks")}</Link>
+              </Button>
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -33,16 +33,12 @@ export default async function LocaleLayout({
   const messages = await getMessages(appLocale);
 
   return (
-    <html lang={appLocale} suppressHydrationWarning>
-      <body className="bg-surface text-foreground antialiased font-sans">
-        <NextIntlClientProvider locale={appLocale} messages={messages} timeZone="UTC">
-          <div className="flex min-h-screen flex-col">
-            <SiteHeader />
-            <main className="flex-1">{children}</main>
-            <SiteFooter />
-          </div>
-        </NextIntlClientProvider>
-      </body>
-    </html>
+    <NextIntlClientProvider locale={appLocale} messages={messages} timeZone="UTC">
+      <div className="flex min-h-screen flex-col">
+        <SiteHeader />
+        <main className="flex-1">{children}</main>
+        <SiteFooter />
+      </div>
+    </NextIntlClientProvider>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,8 @@
 import type { Metadata } from "next";
+import { getLocale } from "next-intl/server";
+import type { ReactNode } from "react";
+
+import { defaultLocale } from "@/i18n/config";
 import "./globals.css";
 
 const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://alias.cards";
@@ -28,10 +32,28 @@ export const metadata: Metadata = {
   },
 };
 
-export default function RootLayout({
-  children,
-}: Readonly<{
-  children: React.ReactNode;
-}>) {
-  return children;
+type RootLayoutProps = Readonly<{
+  children: ReactNode;
+}>;
+
+export default async function RootLayout({ children }: RootLayoutProps) {
+  let locale = defaultLocale;
+
+  try {
+    locale = await getLocale();
+  } catch {
+    locale = defaultLocale;
+  }
+
+  if (!locale) {
+    locale = defaultLocale;
+  }
+
+  return (
+    <html lang={locale} suppressHydrationWarning>
+      <body className="bg-surface text-foreground antialiased font-sans">
+        {children}
+      </body>
+    </html>
+  );
 }


### PR DESCRIPTION
## Summary
- wrap the root layout in a single `<html>`/`<body>` structure while deriving the active locale server-side
- update the locale layout to keep the provider, header, and footer inside the shared document shell
- add a default-locale `/404` page so top-level routes render correctly without the locale layout

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68d325d132a0832cb4afb41dcd1cab86