### PR TITLE
fix: guard responsive mobile header build

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { getLocale } from "next-intl/server";
 import type { ReactNode } from "react";
 
-import { defaultLocale } from "@/i18n/config";
+import { defaultLocale, locales, type AppLocale } from "@/i18n/config";
 import "./globals.css";
 
 const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://alias.cards";
@@ -36,16 +36,19 @@ type RootLayoutProps = Readonly<{
   children: ReactNode;
 }>;
 
+function isAppLocale(locale: string | null | undefined): locale is AppLocale {
+  return locale != null && locales.includes(locale as AppLocale);
+}
+
 export default async function RootLayout({ children }: RootLayoutProps) {
-  let locale = defaultLocale;
+  let locale: AppLocale = defaultLocale;
 
   try {
-    locale = await getLocale();
+    const detectedLocale = await getLocale();
+    if (isAppLocale(detectedLocale)) {
+      locale = detectedLocale;
+    }
   } catch {
-    locale = defaultLocale;
-  }
-
-  if (!locale) {
     locale = defaultLocale;
   }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -37,7 +37,7 @@ type RootLayoutProps = Readonly<{
 }>;
 
 function isAppLocale(locale: string | null | undefined): locale is AppLocale {
-  return locale != null && locales.includes(locale as AppLocale);
+  return locale != null && locales.some((candidate) => candidate === locale);
 }
 
 export default async function RootLayout({ children }: RootLayoutProps) {
@@ -49,7 +49,7 @@ export default async function RootLayout({ children }: RootLayoutProps) {
       locale = detectedLocale;
     }
   } catch {
-    locale = defaultLocale;
+    // During build, getLocale() can throw. Fallback to defaultLocale is intended.
   }
 
   return (

--- a/src/components/mobile-nav.tsx
+++ b/src/components/mobile-nav.tsx
@@ -46,7 +46,7 @@ export function MobileNav({
       </Dialog.Trigger>
       <Dialog.Portal>
         <Dialog.Overlay className="fixed inset-0 z-40 bg-foreground/20 backdrop-blur-sm" />
-        <Dialog.Content className="fixed inset-y-0 right-0 z-50 flex w-full max-w-xs flex-col bg-surface shadow-lg focus:outline-none">
+        <Dialog.Content className="fixed inset-y-0 right-0 z-50 flex w-full max-w-xs flex-col bg-surface shadow-lg">
           <div className="flex items-center justify-between border-b border-foreground/10 px-6 py-4">
             <Dialog.Title className="text-base font-semibold">
               {menuLabel}
@@ -78,7 +78,7 @@ export function MobileNav({
           <div className="border-t border-foreground/10 px-6 py-4">
             <Dialog.Close asChild>
               <Button asChild className="w-full">
-                <Link href={downloadHref} target="_blank" rel="noreferrer">
+                <Link href={downloadHref} target="_blank" rel="noopener noreferrer">
                   {downloadLabel}
                 </Link>
               </Button>

--- a/src/components/mobile-nav.tsx
+++ b/src/components/mobile-nav.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import * as Dialog from "@radix-ui/react-dialog";
+import { Menu, X } from "lucide-react";
+
+import { Link } from "@/i18n/navigation";
+
+import { LangSwitch } from "@/components/lang-switch";
+import { SiteNavLink } from "@/components/site-nav-link";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/cn";
+
+export type MobileNavLink = {
+  href: string;
+  label: string;
+};
+
+interface MobileNavProps {
+  links: MobileNavLink[];
+  downloadHref: string;
+  downloadLabel: string;
+  menuLabel: string;
+  closeLabel: string;
+  triggerClassName?: string;
+}
+
+export function MobileNav({
+  links,
+  downloadHref,
+  downloadLabel,
+  menuLabel,
+  closeLabel,
+  triggerClassName,
+}: MobileNavProps) {
+  return (
+    <Dialog.Root>
+      <Dialog.Trigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className={cn("md:hidden", triggerClassName)}
+        >
+          <Menu className="size-5" aria-hidden="true" />
+          <span className="sr-only">{menuLabel}</span>
+        </Button>
+      </Dialog.Trigger>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-40 bg-foreground/20 backdrop-blur-sm" />
+        <Dialog.Content className="fixed inset-y-0 right-0 z-50 flex w-full max-w-xs flex-col bg-surface shadow-lg focus:outline-none">
+          <div className="flex items-center justify-between border-b border-foreground/10 px-6 py-4">
+            <Dialog.Title className="text-base font-semibold">
+              {menuLabel}
+            </Dialog.Title>
+            <Dialog.Close asChild>
+              <Button variant="ghost" size="icon">
+                <X className="size-5" aria-hidden="true" />
+                <span className="sr-only">{closeLabel}</span>
+              </Button>
+            </Dialog.Close>
+          </div>
+          <div className="flex-1 overflow-y-auto px-6 py-4">
+            <nav className="flex flex-col gap-2">
+              {links.map((link) => (
+                <Dialog.Close asChild key={link.href}>
+                  <SiteNavLink
+                    href={link.href}
+                    className="justify-start rounded-md px-4 py-2 text-base font-medium"
+                  >
+                    {link.label}
+                  </SiteNavLink>
+                </Dialog.Close>
+              ))}
+            </nav>
+            <div className="mt-6 border-t border-foreground/10 pt-4">
+              <LangSwitch />
+            </div>
+          </div>
+          <div className="border-t border-foreground/10 px-6 py-4">
+            <Dialog.Close asChild>
+              <Button asChild className="w-full">
+                <Link href={downloadHref} target="_blank" rel="noreferrer">
+                  {downloadLabel}
+                </Link>
+              </Button>
+            </Dialog.Close>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -16,7 +16,9 @@ export async function SiteHeader() {
     { href: "/decks/upload", label: t("upload") },
   ];
 
-  const downloadHref = "https://github.com/ooodnakov/alias-game/releases/latest";
+  const downloadHref =
+    process.env.NEXT_PUBLIC_DOWNLOAD_URL ||
+    "https://github.com/ooodnakov/alias-game/releases/latest";
   const downloadLabel = t("download");
 
   return (
@@ -34,7 +36,7 @@ export async function SiteHeader() {
         </nav>
         <div className="flex items-center gap-2">
           <Button asChild size="sm" className="hidden sm:inline-flex">
-            <Link href={downloadHref} target="_blank" rel="noreferrer">
+            <Link href={downloadHref} target="_blank" rel="noopener noreferrer">
               {downloadLabel}
             </Link>
           </Button>

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -2,35 +2,52 @@ import { Link } from "@/i18n/navigation";
 import { getTranslations } from "next-intl/server";
 
 import { LangSwitch } from "@/components/lang-switch";
+import { MobileNav } from "@/components/mobile-nav";
 import { SiteNavLink } from "@/components/site-nav-link";
 import { Button } from "@/components/ui/button";
 
 export async function SiteHeader() {
   const t = await getTranslations("nav");
 
+  const links = [
+    { href: "/", label: t("home") },
+    { href: "/decks", label: t("decks") },
+    { href: "/about", label: t("about") },
+    { href: "/decks/upload", label: t("upload") },
+  ];
+
+  const downloadHref = "https://github.com/ooodnakov/alias-game/releases/latest";
+  const downloadLabel = t("download");
+
   return (
     <header className="border-b border-foreground/10 bg-surface/80 backdrop-blur">
-      <div className="mx-auto flex max-w-6xl items-center justify-between gap-6 px-6 py-4">
+      <div className="mx-auto flex max-w-6xl items-center justify-between gap-4 px-4 py-3 sm:px-6">
         <Link href="/" className="text-lg font-semibold tracking-tight">
           Alias
         </Link>
-        <nav className="flex items-center gap-2">
-          <SiteNavLink href="/">{t("home")}</SiteNavLink>
-          <SiteNavLink href="/decks">{t("decks")}</SiteNavLink>
-          <SiteNavLink href="/about">{t("about")}</SiteNavLink>
-          <SiteNavLink href="/decks/upload">{t("upload")}</SiteNavLink>
+        <nav className="hidden items-center gap-2 md:flex">
+          {links.map((link) => (
+            <SiteNavLink key={link.href} href={link.href}>
+              {link.label}
+            </SiteNavLink>
+          ))}
         </nav>
-        <div className="flex items-center gap-3">
-          <Button asChild size="sm">
-            <Link
-              href="https://github.com/ooodnakov/alias-game/releases/latest"
-              target="_blank"
-              rel="noreferrer"
-            >
-              {t("download")}
+        <div className="flex items-center gap-2">
+          <Button asChild size="sm" className="hidden sm:inline-flex">
+            <Link href={downloadHref} target="_blank" rel="noreferrer">
+              {downloadLabel}
             </Link>
           </Button>
-          <LangSwitch />
+          <div className="hidden md:block">
+            <LangSwitch />
+          </div>
+          <MobileNav
+            links={links}
+            downloadHref={downloadHref}
+            downloadLabel={downloadLabel}
+            menuLabel={t("menu")}
+            closeLabel={t("closeMenu")}
+          />
         </div>
       </div>
     </header>

--- a/src/components/site-nav-link.tsx
+++ b/src/components/site-nav-link.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { cva } from "class-variance-authority";
-import type { ReactNode } from "react";
+import { forwardRef, type ReactNode } from "react";
 
 import { useLocale } from "next-intl";
 
@@ -25,35 +25,44 @@ const navLinkStyles = cva(
   },
 );
 
-export function SiteNavLink({
-  href,
-  children,
-}: {
+export type SiteNavLinkProps = {
   href: string;
   children: ReactNode;
-}) {
-  const pathname = usePathname();
-  const locale = useLocale();
+  className?: string;
+  onClick?: () => void;
+};
 
-  let normalizedPath = pathname.startsWith("/") ? pathname : `/${pathname}`;
-  if (normalizedPath === `/${locale}`) {
-    normalizedPath = "/";
-  } else {
-    for (const candidate of locales) {
-      if (normalizedPath.startsWith(`/${candidate}/`)) {
-        normalizedPath = normalizedPath.replace(`/${candidate}`, "");
-        break;
+export const SiteNavLink = forwardRef<HTMLAnchorElement, SiteNavLinkProps>(
+  ({ href, children, className, onClick }, ref) => {
+    const pathname = usePathname();
+    const locale = useLocale();
+
+    let normalizedPath = pathname.startsWith("/") ? pathname : `/${pathname}`;
+    if (normalizedPath === `/${locale}`) {
+      normalizedPath = "/";
+    } else {
+      for (const candidate of locales) {
+        if (normalizedPath.startsWith(`/${candidate}/`)) {
+          normalizedPath = normalizedPath.replace(`/${candidate}`, "");
+          break;
+        }
       }
     }
-  }
 
-  const target = href === "/" ? "/" : href.replace(/\/$/, "");
-  const isActive =
-    normalizedPath === target || normalizedPath.startsWith(`${target}/`);
+    const target = href === "/" ? "/" : href.replace(/\/$/, "");
+    const isActive =
+      normalizedPath === target || normalizedPath.startsWith(`${target}/`);
 
-  return (
-    <Link href={href} className={cn(navLinkStyles({ active: isActive }))}>
-      {children}
-    </Link>
-  );
-}
+    return (
+      <Link
+        ref={ref}
+        href={href}
+        onClick={onClick}
+        className={cn(navLinkStyles({ active: isActive }), className)}
+      >
+        {children}
+      </Link>
+    );
+  });
+
+SiteNavLink.displayName = "SiteNavLink";

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -24,6 +24,7 @@ const buttonVariants = cva(
         sm: "h-8 px-3 text-xs",
         md: "h-10 px-4 text-sm",
         lg: "h-12 px-6 text-base",
+        icon: "size-10 p-0",
       },
     },
     defaultVariants: {

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -4,7 +4,9 @@
     "decks": "Decks",
     "about": "About",
     "upload": "Upload",
-    "download": "Download APK"
+    "download": "Download APK",
+    "menu": "Menu",
+    "closeMenu": "Close menu"
   },
   "footer": {
     "madeWith": "Made with care for parties",

--- a/src/messages/ru.json
+++ b/src/messages/ru.json
@@ -4,7 +4,9 @@
     "decks": "Колоды",
     "about": "О проекте",
     "upload": "Загрузка",
-    "download": "Скачать APK"
+    "download": "Скачать APK",
+    "menu": "Меню",
+    "closeMenu": "Закрыть меню"
   },
   "footer": {
     "madeWith": "Сделано с любовью к вечеринкам",


### PR DESCRIPTION
## Summary
- add a MobileNav dialog for small screens with navigation links, language switcher, and download button
- update the site header layout to hide desktop navigation on mobile and surface the new menu trigger
- allow SiteNavLink to be reused in different contexts and localize menu labels in both languages
- guard locale detection with an AppLocale check so the Next.js build succeeds
- extend button size variants with an icon size for the mobile menu trigger and close controls

## Testing
- pnpm run build
- pnpm run lint

------
https://chatgpt.com/codex/tasks/task_b_68d3aaf0c004832cb2510cc10963a2b1