### PR TITLE
Add caching to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,15 @@ jobs:
         uses: pnpm/action-setup@v4
         with:
           version: 10.5.2
+      - name: Determine pnpm store path
+        run: echo "PNPM_STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.PNPM_STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -30,6 +39,13 @@ jobs:
         run: pnpm run build
       - name: Run unit and integration tests
         run: pnpm run test
+      - name: Cache Playwright binaries
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
       - name: Install Playwright browsers
         run: pnpm exec playwright install --with-deps
       - name: Run E2E tests


### PR DESCRIPTION
## Summary
- add pnpm store caching to the CI workflow to avoid re-installing dependencies
- reuse downloaded Playwright binaries across workflow runs via GitHub Actions cache

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_b_68d678de8504832cba0560e389cea720