### PR TITLE
Fix deck filter navigation for empty query strings

### DIFF
--- a/src/components/deck-filters.tsx
+++ b/src/components/deck-filters.tsx
@@ -8,7 +8,7 @@ import { usePathname, useRouter } from "@/i18n/navigation";
 import { useSearchParams } from "next/navigation";
 
 import { Button } from "@/components/ui/button";
-import { buildDeckFiltersPath } from "./deck-filters-helpers";
+import { buildPathWithQuery } from "./path-helpers";
 
 interface DeckFiltersProps {
   searchPlaceholder: string;
@@ -105,7 +105,7 @@ export function DeckFilters({ searchPlaceholder, labels, available, initial }: D
 
     params.delete("page");
 
-    const target = buildDeckFiltersPath(pathname, params);
+    const target = buildPathWithQuery(pathname, params);
 
     startTransition(() => {
       router.replace(target);
@@ -129,7 +129,7 @@ export function DeckFilters({ searchPlaceholder, labels, available, initial }: D
     params.delete("tags");
     params.delete("nsfw");
     params.delete("page");
-    const target = buildDeckFiltersPath(pathname, params);
+    const target = buildPathWithQuery(pathname, params);
 
     startTransition(() => {
       router.replace(target);

--- a/src/components/path-helpers.ts
+++ b/src/components/path-helpers.ts
@@ -1,4 +1,4 @@
-export function buildDeckFiltersPath(pathname: string, params: URLSearchParams) {
+export function buildPathWithQuery(pathname: string, params: URLSearchParams) {
   const queryString = params.toString();
 
   if (!queryString) {

--- a/tests/unit/deck-filters.test.ts
+++ b/tests/unit/deck-filters.test.ts
@@ -1,18 +1,18 @@
 import { describe, expect, it } from "vitest";
 
-import { buildDeckFiltersPath } from "@/components/deck-filters-helpers";
+import { buildPathWithQuery } from "@/components/path-helpers";
 
-describe("buildDeckFiltersPath", () => {
+describe("buildPathWithQuery", () => {
   it("returns pathname without trailing question mark when no filters are applied", () => {
     const params = new URLSearchParams();
 
-    expect(buildDeckFiltersPath("/decks", params)).toBe("/decks");
+    expect(buildPathWithQuery("/decks", params)).toBe("/decks");
   });
 
   it("appends query parameters when filters are present", () => {
     const params = new URLSearchParams();
     params.set("q", "test");
 
-    expect(buildDeckFiltersPath("/decks", params)).toBe("/decks?q=test");
+    expect(buildPathWithQuery("/decks", params)).toBe("/decks?q=test");
   });
 });


### PR DESCRIPTION
## Summary
- ensure the deck filters component builds navigation targets without a trailing question mark when no filters are active
- add a helper utility and regression tests covering empty and populated filter query scenarios

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_b_68d6de9bc05c832cb7697118e55c4b06